### PR TITLE
Migrate and symlinks fixes

### DIFF
--- a/src/bind_mount.sh
+++ b/src/bind_mount.sh
@@ -25,17 +25,20 @@ link_paths() {
     # other config files
     ln -s "${efs_path}/.config" "${local_path}/.config"
 
+    # Software folders
+    ln -s "${efs_path}/.pixi" "${local_path}/.pixi"
+    ln -s "${efs_path}/micromamba" "${local_path}/micromamba"
+
     # Only link these directories when not in oem_packages mode
     if [[ ${MODE} != "oem_packages" ]]; then
-        # Software folders
-        ln -s "${efs_path}/.pixi" "${local_path}/.pixi"
-        ln -s "${efs_path}/micromamba" "${local_path}/micromamba"
-
         # Ipython folder
         ln -s "${efs_path}/.ipython" "${local_path}/.ipython"
 
         # Cache
         ln -s "${efs_path}/.cache" "${local_path}/.cache"
+
+        # Git repositories
+        ln -s "${efs_path}/ghq" "${local_path}/ghq"
 
         # After installing pixi, it adds the local dir to the PATH through the .bashrc
         # Because we do not want multiple $HOME to front of PATH
@@ -55,11 +58,6 @@ if [ -f "\$HOME/.bashrc" ]; then
 fi
 fi
 EOF
-    fi
-
-    if [[ ${MODE} != "oem_packages" ]]; then
-        # Git repositories
-        ln -s "${efs_path}/ghq" "${local_path}/ghq"
     fi
 
     # ln -s ${efs_path}/.mamba ${local_path}/.mamba

--- a/src/float_wrapper.sh
+++ b/src/float_wrapper.sh
@@ -80,6 +80,7 @@ root_vol_size=""
 publish=""
 dataVolumeOption=""
 verbose=""
+migratePolicy=""
 declare -a float_args=()
 
 while (( "$#" )); do
@@ -102,6 +103,7 @@ while (( "$#" )); do
         --host-script) host_script="$2"; shift 2;;
         --job-script) job_script="$2"; shift 2;;
         # Miscellaneous parameters
+        --migratePolicy) migratePolicy="$2"; shift 2;;
         --dryrun) dryrun="$2"; shift 2;;
         --extra-parameters) extra_parameters="${2//;/ }"; shift 2;;
         --env-parameters) env_parameters="${2//;/ }"; shift 2;;
@@ -117,7 +119,6 @@ float_args+=(
     "-i" "$image" "-c" "$core" "-m" "$mem"
     "--vmPolicy" "$vm_policy"
     "--securityGroup" "$securityGroup"
-    "--migratePolicy" "[disable=true,evadeOOM=false]"
     "--withRoot"
     "--allowList" "[r5*,r6*,r7*,m*]"
     "-j" "$job_script"
@@ -138,6 +139,12 @@ fi
 if [[ -n  "${root_vol_size}" ]]; then
     float_args+=(
         "--rootVolSize" "${root_vol_size}"
+    )
+fi
+
+if [[ -n "${migratePolicy}" ]]; then
+    float_args+=(
+        "--migratePolicy" "${migratePolicy}"
     )
 fi
 

--- a/src/mm_jobman.sh
+++ b/src/mm_jobman.sh
@@ -40,6 +40,7 @@ password=""
 vm_policy=""
 extra_parameters=""
 parallel_commands_given=""
+migratePolicy=""
 
 # Batch-specific optional values
 job_script=""
@@ -692,6 +693,7 @@ submit_each_line_with_float() {
             --job-script "${job_filename}" \
             --dryrun "${dryrun}" \
             --ide "batch" \
+            --verbose \
             --env-parameters "${env_parameters// /;}" \
             --extra-parameters "${extra_parameters// /;}" \
             --job-name "${batch_job_name}"
@@ -817,6 +819,7 @@ submit_interactive_job() {
         --rootVolSize "${root_vol_size}" \
         --host-script "${host_script}" \
         --job-script "${script_dir}/bind_mount.sh" \
+        --migratePolicy "[disable=true,evadeOOM=false]" \
         --dryrun "${dryrun}" \
         --env-parameters "${env_parameters// /;}" \
         --extra-parameters "${extra_parameters// /;}" \

--- a/src/mm_jobman.sh
+++ b/src/mm_jobman.sh
@@ -40,7 +40,6 @@ password=""
 vm_policy=""
 extra_parameters=""
 parallel_commands_given=""
-migratePolicy=""
 
 # Batch-specific optional values
 job_script=""
@@ -51,6 +50,7 @@ min_cores_per_command=0
 min_mem_per_command=0
 no_fail="|| { command_failed=1; break; }"
 no_fail_parallel="--halt now,fail=1"
+declare -a job_script_args=()
 declare -a download_local=()
 declare -a download_remote=()
 declare -a download_include=()
@@ -616,6 +616,47 @@ determine_batch_job_name() {
     echo -e "${job_name}"
 }
 
+generate_job_script_args() {
+    job_script_args=(
+        "--cwd" "${cwd}"
+        "--min-cores-per-command" "${min_cores_per_command}"
+        "--min-mem-per-command" "${min_mem_per_command}"
+        "--no-fail" "${no_fail}"
+        "--no-fail-parallel" "${no_fail_parallel}"
+        "--parallel-commands" "${parallel_commands}"
+    )
+
+    if (( ${#download_local[@]} )); then
+        job_script_args+=(
+            "--download-local" "$(echo "${download_local[@]}" | tr ' ' ';')"
+        )
+    fi
+
+    if (( ${#download_include[@]} )); then
+        job_script_args+=(
+            "--download-include" "$(echo "${download_include[@]}" | tr ' ' ';')"
+        )
+    fi
+
+    if (( ${#upload_local[@]} )); then
+        job_script_args+=(
+            "--upload-local" "$(echo "${upload_local[@]}" | tr ' ' ';')"
+        )
+    fi
+
+    if (( ${#download_remote[@]} )); then
+        job_script_args+=(
+            "--download-remote" "$(echo "${download_remote[@]}" | tr ' ' ';')"
+        )
+    fi
+
+    if (( ${#upload_remote[@]} )); then
+        job_script_args+=(
+            "--upload-remote" "$(echo "${upload_remote[@]}" | tr ' ' ';')"
+        )
+    fi
+}
+
 submit_each_line_with_float() {
     local script_file="$1"
 
@@ -655,22 +696,15 @@ submit_each_line_with_float() {
         # Begin jobs script with bind_mount.sh
         cat "$script_dir/bind_mount.sh" > "${job_filename}"
 
-        "${script_dir}/generate_job_script.sh" \
-            --script_file "${script_file}" \
-            --start "${start}" \
-            --end "${end}" \
-            --cwd "${cwd}" \
-            --download-local "$(echo "${download_local[@]}" | tr ' ' ';')" \
-            --upload-local "$(echo "${upload_local[@]}" | tr ' ' ';')" \
-            --download-remote "$(echo "${download_remote[@]}" | tr ' ' ';')" \
-            --download-include "$(echo "${download_include[@]}" | tr ' ' ';')" \
-            --upload-remote "$(echo "${upload_remote[@]}" | tr ' ' ';')" \
-            --job-filename "${job_filename}" \
-            --min-cores-per-command "${min_cores_per_command}" \
-            --min-mem-per-command "${min_mem_per_command}" \
-            --no-fail "${no_fail}" \
-            --no-fail-parallel "${no_fail_parallel}" \
-            --parallel-commands "${parallel_commands}"
+        generate_job_script_args
+        job_script_args+=(
+            "--script_file" "${script_file}"
+            "--start" "${start}"
+            "--end" "${end}"
+            "--job-filename" "${job_filename}"
+        )
+
+        "${script_dir}/generate_job_script.sh" "${job_script_args[@]}"
 
         # Set batch job name with numeric suffix
         batch_job_name=$(determine_batch_job_name $((j+1)))
@@ -693,7 +727,6 @@ submit_each_line_with_float() {
             --job-script "${job_filename}" \
             --dryrun "${dryrun}" \
             --ide "batch" \
-            --verbose \
             --env-parameters "${env_parameters// /;}" \
             --extra-parameters "${extra_parameters// /;}" \
             --job-name "${batch_job_name}"


### PR DESCRIPTION
This PR fixes two issues:

- We were not linking `/mnt/efs/shared/.pixi` to `${HOME}/.pixi` for historical reasons but need to do so now to fix some breakages
- I mistakenly disabled Waverunner migration of batch jobs when it is only supposed to be disabled for interactive jobs.